### PR TITLE
disable smartweave logger workaround

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,10 @@ import Transaction from "arweave/node/lib/transaction";
 import { GQLEdgeInterface } from "ar-gql/dist/faces";
 
 // eslint-disable-next-line
-console.log = (...x: any[]) => {
-  if (new Error().stack?.includes("smartweave")) return;
-  console.info(...x);
-};
+// console.log = (...x: any[]) => {
+// if (new Error().stack?.includes("smartweave")) return;
+// console.info(...x);
+// };
 
 interface VertoLibOptions {
   useCache?: boolean;
@@ -306,6 +306,7 @@ export default class Verto {
     return getTPTokens(
       this.arweave,
       post,
+      this.useCache,
       this.exchangeContract,
       this.exchangeWallet
     );

--- a/src/lib/get_tp_tokens.ts
+++ b/src/lib/get_tp_tokens.ts
@@ -13,6 +13,7 @@ const unique = (arr: VertoToken[]): VertoToken[] => {
 export const getTPTokens = async (
   client: Arweave,
   post: string,
+  useCache: boolean,
   exchangeContract: string,
   exchangeWallet: string
 ): Promise<VertoToken[]> => {
@@ -20,7 +21,7 @@ export const getTPTokens = async (
 
   const tokens: VertoToken[] = [
     ...(await popularTokens(client, exchangeWallet)),
-    ...(await getTokens(client, exchangeContract)),
+    ...(await getTokens(client, useCache, exchangeContract)),
   ];
   // @ts-ignore
   config.blockedTokens.map((token: string) => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -12,7 +12,7 @@ let vertoInstance: Verto;
 
 describe("E2E Tests", function () {
   before(() => {
-    vertoInstance = new Verto();
+    vertoInstance = new Verto(undefined, undefined, { useCache: true });
   });
 
   it("Assert Verto instance", (done) => {


### PR DESCRIPTION
IIRC It was already fixed with `logger: false` option